### PR TITLE
docs: fix link to the list of supported providers

### DIFF
--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -411,4 +411,4 @@ Non-existent variables declared in the configuration file will raise an error.
     syntax by prepending a second dollar sign like so: ``$${NOT_A_VARIABLE}``.
 
 .. _GitHub: https://raw.githubusercontent.com/adferrand/docker-letsencrypt-dns/master/src/dnsrobocert/schema.yml
-.. _Lexicon Providers configuration reference: https://dnsrobocert.readthedocs.io/en/latest/lexicon_providers_config.html
+.. _Lexicon Providers configuration reference: https://dnsrobocert.readthedocs.io/en/latest/providers_options.html


### PR DESCRIPTION
`grep` finds no more occurrences of the invalid link, we should be set!