### PR TITLE
update link to DockerHub page

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -362,7 +362,7 @@ To use the "one-shot" mode, simply set the `--one-shot` flag to the command line
 
 .. _Pipx: https://github.com/pipxproject/pipx
 .. _Pip: https://docs.python.org/fr/3.6/installing/index.html
-.. _DockerHub: https://hub.docker.com/r/adferrand/letsencrypt-dns/
+.. _DockerHub: https://hub.docker.com/r/adferrand/dnsrobocert
 .. _Configuration reference: https://dnsrobocert.readthedocs.io/en/latest/configuration_reference.html
 .. _Lexicon Providers configuration reference: https://dnsrobocert.readthedocs.io/en/latest/providers_options.html#supported-providers
 .. _Certbot layout convention: https://certbot.eff.org/docs/using.html#where-are-my-certificates


### PR DESCRIPTION
adferrand/letsencrypt-dns has a deprecation note and links to adferrand/dnsrobocert.
The latter is also the image described in the current documentation.