### PR TITLE
Update broken spectrum.chat link to Github Discussions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,4 +109,4 @@ Please have a look at the `Developer guide`_ page to know how to start.
 .. _User guide: https://dnsrobocert.readthedocs.io/en/latest/user_guide.html
 .. _Lexicon provider configuration: https://dnsrobocert.readthedocs.io/en/latest/providers_options.html
 .. _Developer guide: https://dnsrobocert.readthedocs.io/en/latest/developer_guide.html
-.. _DNSroboCert community on Spectrum: https://spectrum.chat/dnsrobocert
+.. _DNSroboCert community on Github Discussions: https://github.com/adferrand/dnsrobocert/discussions


### PR DESCRIPTION
Currently if you click the "DNSroboCert community on Spectrum" link at the bottom of the README, the browser gives you a warning since the Spectrum url doesn't exist anymore. I assume you want to re-direct to Github Discussions, so I made the change. 

Thank you for the great project and for supporting Porkbun DNS :). Solved a real problem for me today!