### PR TITLE
Fix config example in configuration_reference.rst

### DIFF
--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -395,7 +395,7 @@ be defined in each relevant certificate configuration.
         - containers:
           - container1
           - container2
-          swarm_services:
+        - swarm_services:
           - service1
 
 ``autocmd``


### PR DESCRIPTION
Added a missing dash in the example yaml configuration section for the "autorestart property". https://dnsrobocert.readthedocs.io/en/latest/configuration_reference.html#autorestart