### PR TITLE
Add support for ACME certificate profiles (short-lived certificates)

### DIFF
--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -339,6 +339,16 @@ be defined in each relevant certificate configuration.
     * *type*: ``string``
     * *default*: ``rsa`` (a RSA-type key will be used)
 
+``acme_profile``
+~~~~~~~~~~~~~~~~
+    * ACME certificate profile to use. Must be ``tlsserver`` (standard 90-day certificate) or
+      ``shortlived`` (6-day certificate). Short-lived certificates provide better security by
+      reducing the exposure window if a private key is compromised, but require more frequent
+      renewal (every 2-3 days). See `Let's Encrypt ACME Profiles`_ for more information.
+    * *type*: ``string``
+    * *default*: not set (uses the CA's default profile, typically ``tlsserver``)
+
+.. _Let's Encrypt ACME Profiles: https://letsencrypt.org/2025/01/09/acme-profiles
 
 .. _link: https://letsencrypt.org/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html#the-advantages-of-a-cname
 

--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -347,6 +347,8 @@ be defined in each relevant certificate configuration.
       renewal (every 2-3 days). See `Let's Encrypt ACME Profiles`_ for more information.
     * *type*: ``string``
     * *default*: not set (uses the CA's default profile, typically ``tlsserver``)
+    * *note*: When using ``shortlived``, ensure DNSroboCert runs frequently (e.g., hourly via
+      ``crontab_renew``) to handle the tighter renewal window. Requires certbot >= 2.11.0.
 
 .. _Let's Encrypt ACME Profiles: https://letsencrypt.org/2025/01/09/acme-profiles
 

--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -339,6 +339,18 @@ be defined in each relevant certificate configuration.
     * *type*: ``string``
     * *default*: ``rsa`` (a RSA-type key will be used)
 
+``acme_profile``
+~~~~~~~~~~~~~~~~
+    * ACME certificate profile to use. Must be ``tlsserver`` (standard 90-day certificate) or
+      ``shortlived`` (6-day certificate). Short-lived certificates provide better security by
+      reducing the exposure window if a private key is compromised, but require more frequent
+      renewal (every 2-3 days). See `Let's Encrypt ACME Profiles`_ for more information.
+    * *type*: ``string``
+    * *default*: not set (uses the CA's default profile, typically ``tlsserver``)
+    * *note*: When using ``shortlived``, ensure DNSroboCert runs frequently (e.g., hourly via
+      ``crontab_renew``) to handle the tighter renewal window.
+
+.. _Let's Encrypt ACME Profiles: https://letsencrypt.org/2025/01/09/acme-profiles
 
 .. _link: https://letsencrypt.org/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html#the-advantages-of-a-cname
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ readme = "README.rst"
 
 requires-python = ">=3.10"
 dependencies = [
-    "acme>=2",
-    "certbot>=2",
+    "acme>=4",
+    "certbot>=4",
     "dns-lexicon[full]>=3.14.0",
     "cryptography>=2",
     "cffi>=1",

--- a/src/dnsrobocert/core/certbot.py
+++ b/src/dnsrobocert/core/certbot.py
@@ -72,6 +72,7 @@ def certonly(
     force_renew: bool = False,
     reuse_key: bool = False,
     key_type: str = "rsa",
+    acme_profile: str | None = None,
 ) -> None:
     if not domains:
         return
@@ -85,6 +86,8 @@ def certonly(
         additional_params.append("--reuse-key")
     if key_type:
         additional_params.extend(["--key-type", key_type])
+    if acme_profile:
+        additional_params.extend(["--preferred-profile", acme_profile])
 
     for domain in domains:
         additional_params.append("-d")
@@ -134,6 +137,7 @@ def _issue(config_path: str, directory_path: str, lock: threading.Lock) -> None:
                 force_renew = certificate.get("force_renew", False)
                 reuse_key = certificate.get("reuse_key", False)
                 key_type = certificate.get("key_type", "rsa")
+                acme_profile = certificate.get("acme_profile")
                 LOGGER.info(
                     f"Handling the certificate for domain(s): {', '.join(domains)}"
                 )
@@ -146,6 +150,7 @@ def _issue(config_path: str, directory_path: str, lock: threading.Lock) -> None:
                     force_renew=force_renew,
                     reuse_key=reuse_key,
                     key_type=key_type,
+                    acme_profile=acme_profile,
                 )
             except BaseException as error:
                 LOGGER.error(

--- a/src/dnsrobocert/core/certbot.py
+++ b/src/dnsrobocert/core/certbot.py
@@ -72,6 +72,7 @@ def certonly(
     force_renew: bool = False,
     reuse_key: bool = False,
     key_type: str = "rsa",
+    acme_profile: str | None = None,
 ) -> None:
     if not domains:
         return
@@ -85,6 +86,8 @@ def certonly(
         additional_params.append("--reuse-key")
     if key_type:
         additional_params.extend(["--key-type", key_type])
+    if acme_profile:
+        additional_params.extend(["--preferred-profile", acme_profile])
 
     for domain in domains:
         additional_params.append("-d")
@@ -133,7 +136,8 @@ def _issue(config_path: str, directory_path: str, lock: threading.Lock) -> None:
                 domains = certificate["domains"]
                 force_renew = certificate.get("force_renew", False)
                 reuse_key = certificate.get("reuse_key", False)
-                key_type = certificate.get("key_type", "rsa")
+                key_type: str = certificate.get("key_type", "rsa")
+                acme_profile: str | None = certificate.get("acme_profile")
                 LOGGER.info(
                     f"Handling the certificate for domain(s): {', '.join(domains)}"
                 )
@@ -146,6 +150,7 @@ def _issue(config_path: str, directory_path: str, lock: threading.Lock) -> None:
                     force_renew=force_renew,
                     reuse_key=reuse_key,
                     key_type=key_type,
+                    acme_profile=acme_profile,
                 )
             except BaseException as error:
                 LOGGER.error(

--- a/src/dnsrobocert/core/certbot.py
+++ b/src/dnsrobocert/core/certbot.py
@@ -136,8 +136,8 @@ def _issue(config_path: str, directory_path: str, lock: threading.Lock) -> None:
                 domains = certificate["domains"]
                 force_renew = certificate.get("force_renew", False)
                 reuse_key = certificate.get("reuse_key", False)
-                key_type = certificate.get("key_type", "rsa")
-                acme_profile = certificate.get("acme_profile")
+                key_type: str = certificate.get("key_type", "rsa")
+                acme_profile: str | None = certificate.get("acme_profile")
                 LOGGER.info(
                     f"Handling the certificate for domain(s): {', '.join(domains)}"
                 )

--- a/src/dnsrobocert/schema.yml
+++ b/src/dnsrobocert/schema.yml
@@ -132,6 +132,9 @@ properties:
         key_type:
           type: string
           enum: [rsa, ecdsa]
+        acme_profile:
+          type: string
+          enum: [tlsserver, shortlived]
       required: [domains, profile]
       additionalProperties: false
 additionalProperties: false

--- a/test/unit_tests/certbot_test.py
+++ b/test/unit_tests/certbot_test.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+from dnsrobocert.core import certbot
+
+
+def test_certonly_with_acme_profile(tmp_path):
+    """Test that acme_profile is passed to certbot as --preferred-profile."""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        """\
+draft: true
+profiles:
+- name: test
+  provider: test
+certificates:
+- domains: [test.example.com]
+  profile: test
+"""
+    )
+
+    with mock.patch("dnsrobocert.core.utils.execute") as mock_execute:
+        lock = mock.MagicMock()
+        certbot.certonly(
+            config_path=str(config_path),
+            directory_path=str(tmp_path),
+            lineage="test.example.com",
+            lock=lock,
+            domains=["test.example.com"],
+            acme_profile="shortlived",
+        )
+
+        mock_execute.assert_called_once()
+        call_args = mock_execute.call_args[0][0]
+        assert "--preferred-profile" in call_args
+        assert "shortlived" in call_args
+        profile_idx = call_args.index("--preferred-profile")
+        assert call_args[profile_idx + 1] == "shortlived"
+
+
+def test_certonly_without_acme_profile(tmp_path):
+    """Test that --preferred-profile is not passed when acme_profile is not set."""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        """\
+draft: true
+profiles:
+- name: test
+  provider: test
+certificates:
+- domains: [test.example.com]
+  profile: test
+"""
+    )
+
+    with mock.patch("dnsrobocert.core.utils.execute") as mock_execute:
+        lock = mock.MagicMock()
+        certbot.certonly(
+            config_path=str(config_path),
+            directory_path=str(tmp_path),
+            lineage="test.example.com",
+            lock=lock,
+            domains=["test.example.com"],
+        )
+
+        mock_execute.assert_called_once()
+        call_args = mock_execute.call_args[0][0]
+        assert "--preferred-profile" not in call_args

--- a/test/unit_tests/config_test.py
+++ b/test/unit_tests/config_test.py
@@ -96,6 +96,47 @@ def test_wildcard_lineage() -> None:
     assert config.get_lineage(certificate) == "example.com"
 
 
+def test_good_config_with_acme_profile(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    with open(str(config_path), "w") as f:
+        f.write(
+            """\
+draft: true
+profiles:
+- name: one
+  provider: one
+certificates:
+- domains: [test.example.com]
+  profile: one
+  acme_profile: shortlived
+"""
+        )
+
+    parsed = config.load(str(config_path))
+    assert parsed
+    assert parsed["certificates"][0]["acme_profile"] == "shortlived"
+
+
+def test_bad_config_invalid_acme_profile(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    with open(str(config_path), "w") as f:
+        f.write(
+            """\
+draft: true
+profiles:
+- name: one
+  provider: one
+certificates:
+- domains: [test.example.com]
+  profile: one
+  acme_profile: invalid_profile
+"""
+        )
+
+    parsed = config.load(str(config_path))
+    assert not parsed
+
+
 def test_environment_variable_injection(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yml"
     with open(str(config_path), "w") as f:

--- a/test/unit_tests/config_test.py
+++ b/test/unit_tests/config_test.py
@@ -86,6 +86,47 @@ def test_wildcard_lineage() -> None:
     assert config.get_lineage(certificate) == "example.com"
 
 
+def test_good_config_with_acme_profile(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    with open(str(config_path), "w") as f:
+        f.write(
+            """\
+draft: true
+profiles:
+- name: one
+  provider: one
+certificates:
+- domains: [test.example.com]
+  profile: one
+  acme_profile: shortlived
+"""
+        )
+
+    parsed = config.load(str(config_path))
+    assert parsed
+    assert parsed["certificates"][0]["acme_profile"] == "shortlived"
+
+
+def test_bad_config_invalid_acme_profile(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    with open(str(config_path), "w") as f:
+        f.write(
+            """\
+draft: true
+profiles:
+- name: one
+  provider: one
+certificates:
+- domains: [test.example.com]
+  profile: one
+  acme_profile: invalid_profile
+"""
+        )
+
+    parsed = config.load(str(config_path))
+    assert not parsed
+
+
 def test_environment_variable_injection(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yml"
     with open(str(config_path), "w") as f:

--- a/uv.lock
+++ b/uv.lock
@@ -847,8 +847,8 @@ doc = [
 
 [package.metadata]
 requires-dist = [
-    { name = "acme", specifier = ">=2" },
-    { name = "certbot", specifier = ">=2" },
+    { name = "acme", specifier = ">=4" },
+    { name = "certbot", specifier = ">=4" },
     { name = "cffi", specifier = ">=1" },
     { name = "colorama", specifier = ">=0" },
     { name = "coloredlogs", specifier = ">=14" },


### PR DESCRIPTION
## Summary

Let's Encrypt now supports [ACME certificate profiles](https://letsencrypt.org/2025/01/09/acme-profiles), including **short-lived 6-day certificates** via the `shortlived` profile.

This PR adds an optional `acme_profile` configuration option for certificates that passes `--preferred-profile` to certbot.

## Example usage

```yaml
certificates:
  - profile: cloudflare
    domains:
      - "*.example.com"
      - "example.com"
    acme_profile: shortlived
```

## Changes

- **schema.yml**: Added `acme_profile` enum (tlsserver, shortlived)
- **certbot.py**: Pass `--preferred-profile` flag when `acme_profile` is set
- **pyproject.toml**: Raised the minimal `certbot` requirement from `>=2` to `>=4`, and `acme` alongside it
- **configuration_reference.rst**: Added documentation
- **config_test.py**: Added validation tests
- **certbot_test.py**: Added unit tests for flag passing

## Notes

- `--preferred-profile` was introduced in [certbot 4.0.0](https://github.com/certbot/certbot/blob/master/certbot/CHANGELOG.md#400---2025-04-07), which is why the minimal requirement is now `>=4`
- Short-lived certs require more frequent renewal (every 2-3 days vs monthly)
- Users should adjust `crontab_renew` accordingly when using `shortlived`
- Uses `--preferred-profile` (falls back to default if unavailable) rather than `--required-profile`

## References

- [Let's Encrypt ACME Profiles](https://letsencrypt.org/2025/01/09/acme-profiles)
- [6-day certificates announcement](https://letsencrypt.org/2025/01/16/6-day-and-ip-certs)
- [Certbot 4.0 support](https://www.eff.org/deeplinks/2025/04/certbot-40-long-live-short-lived-certs)
